### PR TITLE
feat(user) : 카카오 로그인 연동 기능 추가 및 JWT 인증 흐름 구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// JWT 생성/파싱용 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/syu/cara/config/SecurityConfig.java
+++ b/src/main/java/com/syu/cara/config/SecurityConfig.java
@@ -1,23 +1,46 @@
 package com.syu.cara.config;
 
+import com.syu.cara.user.security.JwtAuthenticationFilter;
+import com.syu.cara.user.security.JwtService;
+import com.syu.cara.user.service.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-/**
- * 테스트용이거나 간단히 모든 요청을 허용하고 싶을 때 Security를 비활성화하는 설정.
- */
 @Configuration
 public class SecurityConfig {
+
+    private final JwtService jwtService;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public SecurityConfig(JwtService jwtService,
+                          CustomUserDetailsService customUserDetailsService) {
+        this.jwtService = jwtService;
+        this.customUserDetailsService = customUserDetailsService;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())       // CSRF 비활성화
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()       // 모든 요청을 인증 없이 허용
+                // “카카오 로그인” POST 엔드포인트 (프로그램 내부 테스트용)
+                .requestMatchers("/api/auth/kakao").permitAll()
+                // **콜백용 GET 엔드포인트도 반드시 permitAll 처리해줘야 합니다**
+                .requestMatchers("/oauth/kakao/callback").permitAll()
+                // 그 외는 인증 필요
+                .anyRequest().authenticated()
             );
+
+        // JWT 필터 등록 (있다면)
+        JwtAuthenticationFilter jwtFilter =
+            new JwtAuthenticationFilter(jwtService, customUserDetailsService);
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 }

--- a/src/main/java/com/syu/cara/config/SecurityConfig.java
+++ b/src/main/java/com/syu/cara/config/SecurityConfig.java
@@ -29,9 +29,9 @@ public class SecurityConfig {
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 // “카카오 로그인” POST 엔드포인트 (프로그램 내부 테스트용)
-                .requestMatchers("/api/auth/kakao").permitAll()
+                .requestMatchers("/api/v1/auth/kakao").permitAll()
                 // **콜백용 GET 엔드포인트도 반드시 permitAll 처리해줘야 합니다**
-                .requestMatchers("/oauth/kakao/callback").permitAll()
+                .requestMatchers("/v1/oauth/kakao/callback").permitAll()
                 // 그 외는 인증 필요
                 .anyRequest().authenticated()
             );

--- a/src/main/java/com/syu/cara/user/controller/AuthController.java
+++ b/src/main/java/com/syu/cara/user/controller/AuthController.java
@@ -2,37 +2,80 @@ package com.syu.cara.user.controller;
 
 import com.syu.cara.user.dto.KakaoAuthRequest;
 import com.syu.cara.user.dto.KakaoAuthResponse;
-import com.syu.cara.user.service.UserService;
+import com.syu.cara.user.dto.KakaoUserInfoDTO;
+import com.syu.cara.user.domain.User;
+import com.syu.cara.user.repository.UserRepository;
+import com.syu.cara.user.service.KakaoClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final UserService userService;
+    private final KakaoClient kakaoClient;
+    private final UserRepository userRepository;
+    // (추가로 JwtService 같은 걸 주입하려면 여기에 필드 선언)
 
-    public AuthController(UserService userService) {
-        this.userService = userService;
+    public AuthController(KakaoClient kakaoClient,
+                          UserRepository userRepository /*, JwtService jwtService */) {
+        this.kakaoClient    = kakaoClient;
+        this.userRepository = userRepository;
+        // this.jwtService = jwtService;
     }
 
     @PostMapping("/kakao")
     public ResponseEntity<KakaoAuthResponse> kakaoLogin(@RequestBody KakaoAuthRequest request) {
+        KakaoUserInfoDTO kakaoInfo;
         try {
-            KakaoAuthResponse response = userService.loginWithKakao(request);
-            return ResponseEntity.ok(response);
+            // 1) 카카오 서버에서 사용자 정보 가져오기 (예외 발생 가능)
+            kakaoInfo = kakaoClient.getKakaoUserInfo(request.getAccessToken());
         } catch (RuntimeException ex) {
-            // 예: Invalid access token
-            throw new ResponseStatusException(
-                HttpStatus.UNAUTHORIZED,
-                "카카오 인증 실패",
-                ex
-            );
+            // 잘못된 토큰 등으로 카카오 클라이언트가 RuntimeException을 던지면 401로 응답
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+
+        // 2) 정상적으로 사용자 정보를 받아왔을 때 처리 흐름
+        String kakaoId = kakaoInfo.getId();                     // ex: "55555"
+        String loginId = "kakao_" + kakaoId;                     // ex: "kakao_55555"
+        boolean isNewUser;
+
+        // (Optional<User>로 리턴한다고 가정)
+        Optional<User> optionalExisting = userRepository.findByKakaoId(kakaoId);
+        User userEntity;
+
+        if (optionalExisting.isEmpty()) {
+            // → 신규 회원
+            isNewUser = true;
+            User newUser = User.builder()
+                    .kakaoId(kakaoId)
+                    .loginId(loginId)
+                    .email(kakaoInfo.getKakao_account().getEmail())
+                    .fullName(kakaoInfo.getProperties().getNickname())
+                    .profileImageUrl(kakaoInfo.getProperties().getProfile_image())
+                    // 필요한 다른 필드가 있으면 추가…
+                    .build();
+            userEntity = userRepository.save(newUser);
+        } else {
+            // → 기존 회원
+            isNewUser = false;
+            userEntity = optionalExisting.get();
+        }
+
+        // 3) JWT 토큰 생성 (예시로 Fake 토큰)
+        String jwtToken = /* jwtService.generateToken(userEntity) */ "fake-jwt-" + userEntity.getUserId();
+
+        // 4) 응답 DTO 작성
+        KakaoAuthResponse responseDto = KakaoAuthResponse.builder()
+                .userId(userEntity.getUserId())
+                .loginId(userEntity.getLoginId())
+                .isNewUser(isNewUser)
+                .jwtToken(jwtToken)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/syu/cara/user/controller/KakaoOAuthCallbackController.java
+++ b/src/main/java/com/syu/cara/user/controller/KakaoOAuthCallbackController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/oauth/kakao")
+@RequestMapping("/v1/oauth/kakao")
 public class KakaoOAuthCallbackController {
 
     private final KakaoClient kakaoClient;

--- a/src/main/java/com/syu/cara/user/controller/KakaoOAuthCallbackController.java
+++ b/src/main/java/com/syu/cara/user/controller/KakaoOAuthCallbackController.java
@@ -1,0 +1,90 @@
+package com.syu.cara.user.controller;
+
+import com.syu.cara.user.domain.User;
+import com.syu.cara.user.dto.KakaoAuthResponse;
+import com.syu.cara.user.dto.KakaoUserInfoDTO;
+import com.syu.cara.user.repository.UserRepository;
+import com.syu.cara.user.security.JwtService;
+import com.syu.cara.user.service.KakaoClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/oauth/kakao")
+public class KakaoOAuthCallbackController {
+
+    private final KakaoClient kakaoClient;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    public KakaoOAuthCallbackController(KakaoClient kakaoClient,
+                                       UserRepository userRepository,
+                                       JwtService jwtService) {
+        this.kakaoClient    = kakaoClient;
+        this.userRepository = userRepository;
+        this.jwtService     = jwtService;
+    }
+
+    /**
+     * (1) 카카오 로그인 버튼 클릭 → 카카오 인증 화면 → 사용자 동의 후
+     * 카카오가 이 콜백으로 인가 코드를 전송해 준다.
+     *
+     * GET /oauth/kakao/callback?code={인가코드값}&state={원래 state}
+     */
+    @GetMapping("/callback")
+    public ResponseEntity<?> kakaoCallback(@RequestParam("code") String code,
+                                           @RequestParam(value = "state", required = false) String state) {
+        // 1) 인가 코드로 액세스 토큰 발급 요청
+        String accessToken;
+        try {
+            accessToken = kakaoClient.getAccessToken(code);
+        } catch (RuntimeException ex) {
+            // 카카오 인증 실패 혹은 잘못된 인가 코드 Exception
+            return ResponseEntity.badRequest()
+                    .body("카카오에서 액세스 토큰 발급 실패: " + ex.getMessage());
+        }
+
+        // 2) 액세스 토큰으로 카카오 사용자 정보 조회
+        KakaoUserInfoDTO kakaoInfo = kakaoClient.getKakaoUserInfo(accessToken);
+        String kakaoId = kakaoInfo.getId();
+        String loginId = "kakao_" + kakaoId;
+
+        // 3) DB 에 기존 사용자 여부 확인 → 신규이면 저장
+        Optional<User> optionalUser = userRepository.findByKakaoId(kakaoId);
+        User userEntity;
+        boolean isNewUser;
+        if (optionalUser.isEmpty()) {
+            isNewUser = true;
+            User newUser = User.builder()
+                    .kakaoId(kakaoId)
+                    .loginId(loginId)
+                    .email(kakaoInfo.getKakao_account().getEmail())
+                    .fullName(kakaoInfo.getProperties().getNickname())
+                    .profileImageUrl(kakaoInfo.getProperties().getProfile_image())
+                    .build();
+            userEntity = userRepository.save(newUser);
+        } else {
+            isNewUser = false;
+            userEntity = optionalUser.get();
+        }
+
+        // 4) JWT 발급 (User 객체를 넘겨서 내부에서 userId, loginId 등을 claim 추가)
+        String jwtToken = jwtService.generateToken(userEntity);
+
+        // 5) 클라이언트(프론트) 쪽으로 어떻게 전달할지는 상황에 따라 선택
+        //    아래 예시는 “간단하게 JSON으로 반환”하는 방식입니다.
+        KakaoAuthResponse responseDto = KakaoAuthResponse.builder()
+                .userId(userEntity.getUserId())
+                .loginId(userEntity.getLoginId())
+                .isNewUser(isNewUser)
+                .jwtToken(jwtToken)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/syu/cara/user/controller/KakaoOAuthController.java
+++ b/src/main/java/com/syu/cara/user/controller/KakaoOAuthController.java
@@ -1,54 +1,53 @@
 package com.syu.cara.user.controller;
 
+import com.syu.cara.user.domain.User;
 import com.syu.cara.user.dto.KakaoAuthRequest;
 import com.syu.cara.user.dto.KakaoAuthResponse;
 import com.syu.cara.user.dto.KakaoUserInfoDTO;
-import com.syu.cara.user.domain.User;
 import com.syu.cara.user.repository.UserRepository;
+import com.syu.cara.user.security.JwtService;
 import com.syu.cara.user.service.KakaoClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/auth")
-public class AuthController {
-
+public class KakaoOAuthController {
     private final KakaoClient kakaoClient;
     private final UserRepository userRepository;
-    // (추가로 JwtService 같은 걸 주입하려면 여기에 필드 선언)
+    private final JwtService jwtService;
 
-    public AuthController(KakaoClient kakaoClient,
-                          UserRepository userRepository /*, JwtService jwtService */) {
+    public KakaoOAuthController(KakaoClient kakaoClient,
+                                UserRepository userRepository,
+                                JwtService jwtService) {
         this.kakaoClient    = kakaoClient;
         this.userRepository = userRepository;
-        // this.jwtService = jwtService;
+        this.jwtService     = jwtService;
     }
 
     @PostMapping("/kakao")
     public ResponseEntity<KakaoAuthResponse> kakaoLogin(@RequestBody KakaoAuthRequest request) {
         KakaoUserInfoDTO kakaoInfo;
         try {
-            // 1) 카카오 서버에서 사용자 정보 가져오기 (예외 발생 가능)
             kakaoInfo = kakaoClient.getKakaoUserInfo(request.getAccessToken());
         } catch (RuntimeException ex) {
-            // 잘못된 토큰 등으로 카카오 클라이언트가 RuntimeException을 던지면 401로 응답
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // 2) 정상적으로 사용자 정보를 받아왔을 때 처리 흐름
-        String kakaoId = kakaoInfo.getId();                     // ex: "55555"
-        String loginId = "kakao_" + kakaoId;                     // ex: "kakao_55555"
+        String kakaoId = kakaoInfo.getId();
+        String loginId = "kakao_" + kakaoId;
         boolean isNewUser;
 
-        // (Optional<User>로 리턴한다고 가정)
-        Optional<User> optionalExisting = userRepository.findByKakaoId(kakaoId);
+        Optional<User> optionalUser = userRepository.findByKakaoId(kakaoId);
         User userEntity;
 
-        if (optionalExisting.isEmpty()) {
-            // → 신규 회원
+        if (optionalUser.isEmpty()) {
             isNewUser = true;
             User newUser = User.builder()
                     .kakaoId(kakaoId)
@@ -56,19 +55,15 @@ public class AuthController {
                     .email(kakaoInfo.getKakao_account().getEmail())
                     .fullName(kakaoInfo.getProperties().getNickname())
                     .profileImageUrl(kakaoInfo.getProperties().getProfile_image())
-                    // 필요한 다른 필드가 있으면 추가…
                     .build();
             userEntity = userRepository.save(newUser);
         } else {
-            // → 기존 회원
-            isNewUser = false;
-            userEntity = optionalExisting.get();
+            isNewUser  = false;
+            userEntity = optionalUser.get();
         }
 
-        // 3) JWT 토큰 생성 (예시로 Fake 토큰)
-        String jwtToken = /* jwtService.generateToken(userEntity) */ "fake-jwt-" + userEntity.getUserId();
+        String jwtToken = jwtService.generateToken(userEntity);
 
-        // 4) 응답 DTO 작성
         KakaoAuthResponse responseDto = KakaoAuthResponse.builder()
                 .userId(userEntity.getUserId())
                 .loginId(userEntity.getLoginId())

--- a/src/main/java/com/syu/cara/user/controller/KakaoOAuthController.java
+++ b/src/main/java/com/syu/cara/user/controller/KakaoOAuthController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 public class KakaoOAuthController {
     private final KakaoClient kakaoClient;
     private final UserRepository userRepository;

--- a/src/main/java/com/syu/cara/user/controller/UserController.java
+++ b/src/main/java/com/syu/cara/user/controller/UserController.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 public class UserController {
 
     private final UserProfileService profileService;

--- a/src/main/java/com/syu/cara/user/controller/UserController.java
+++ b/src/main/java/com/syu/cara/user/controller/UserController.java
@@ -1,0 +1,22 @@
+package com.syu.cara.user.controller;
+
+import com.syu.cara.user.dto.UserProfileResponse;
+import com.syu.cara.user.service.UserProfileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserProfileService profileService;
+
+    public UserController(UserProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> getMyProfile() {
+        return ResponseEntity.ok(profileService.getMyProfile());
+    }
+}

--- a/src/main/java/com/syu/cara/user/controller/UserController.java
+++ b/src/main/java/com/syu/cara/user/controller/UserController.java
@@ -1,22 +1,63 @@
 package com.syu.cara.user.controller;
 
+import com.syu.cara.user.domain.User;
 import com.syu.cara.user.dto.UserProfileResponse;
-import com.syu.cara.user.service.UserProfileService;
+import com.syu.cara.user.repository.UserRepository;
+import com.syu.cara.user.security.JwtService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/users")
 public class UserController {
 
-    private final UserProfileService profileService;
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
 
-    public UserController(UserProfileService profileService) {
-        this.profileService = profileService;
+    public UserController(JwtService jwtService,
+                          UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
     }
 
     @GetMapping("/me")
-    public ResponseEntity<UserProfileResponse> getMyProfile() {
-        return ResponseEntity.ok(profileService.getMyProfile());
+    public ResponseEntity<UserProfileResponse> getMyProfile(
+            @RequestHeader("Authorization") String authHeader) {
+
+        // 1) 헤더에서 Bearer 제거
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String token = authHeader.substring(7);
+
+        // 2) 토큰 검증
+        if (!jwtService.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 3) 토큰에서 userId 꺼내서 조회
+        Long userId = jwtService.getUserIdFromToken(token);
+        Optional<User> opt = userRepository.findById(userId);
+        if (opt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        User u = opt.get();
+
+        // 4) DTO로 변환
+        UserProfileResponse dto = new UserProfileResponse(
+            u.getLoginId(),
+            u.getEmail(),
+            u.getFullName(),
+            u.getProfileImageUrl(),
+            u.getDriverLicenseNumber(),
+            u.getAddress()
+        );
+        return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/com/syu/cara/user/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/syu/cara/user/dto/KakaoTokenResponse.java
@@ -1,0 +1,26 @@
+package com.syu.cara.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;                   // 액세스 토큰 만료 시간(초)
+
+    @JsonProperty("refresh_token_expires_in")
+    private Long refreshTokenExpiresIn;       // 리프레시 토큰 만료 시간(초)
+
+    private String scope;                     // (예: "account_email profile")
+}

--- a/src/main/java/com/syu/cara/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/syu/cara/user/dto/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.syu.cara.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class UserInfoResponse {
+    private Long userId;
+    private String loginId;
+    private String fullName;
+    private String email;
+    private String phoneNumber;
+    private String profileImageUrl;
+    private String driverLicenseNumber;
+    private LocalDate birthDate;
+    private String address;
+}
+

--- a/src/main/java/com/syu/cara/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/syu/cara/user/dto/UserProfileResponse.java
@@ -10,6 +10,6 @@ public class UserProfileResponse {
     private String email;
     private String fullName;
     private String profileImageUrl;
-    private String driver_license;
+    private String driverLicense;
     private String address;
 }

--- a/src/main/java/com/syu/cara/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/syu/cara/user/dto/UserProfileResponse.java
@@ -1,0 +1,15 @@
+package com.syu.cara.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserProfileResponse {
+    private String loginId;
+    private String email;
+    private String fullName;
+    private String profileImageUrl;
+    private String driver_license;
+    private String address;
+}

--- a/src/main/java/com/syu/cara/user/repository/UserRepository.java
+++ b/src/main/java/com/syu/cara/user/repository/UserRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByKakaoId(String loginId);
+    Optional<User> findByKakaoId(String kakaoId);
+    Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/com/syu/cara/user/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/syu/cara/user/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.syu.cara.user.security;
+
+import com.syu.cara.user.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 매 요청마다 Authorization 헤더의 Bearer 토큰을 확인하고,
+ * 유효한 경우 SecurityContext에 인증 정보를 설정하는 필터
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final CustomUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService,
+                                   CustomUserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1) Authorization 헤더에서 토큰 추출 (Bearer {token})
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            // 2) 토큰 검증
+            if (jwtService.validateToken(token)) {
+                // 3) 토큰에서 꺼낸 userId 또는 loginId 정보를 통해 UserDetails 조회
+                Long userId = jwtService.getUserIdFromToken(token);
+
+                // 예시: userDetailsService 로부터 UserDetails 객체를 얻어서 Authentication 생성
+                var userDetails = userDetailsService.loadUserById(userId);
+                var auth = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/syu/cara/user/security/JwtService.java
+++ b/src/main/java/com/syu/cara/user/security/JwtService.java
@@ -1,0 +1,100 @@
+package com.syu.cara.user.security;
+
+import com.syu.cara.user.domain.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@Service
+public class JwtService {
+
+    // application.yml 또는 properties에서 값을 주입받는다.
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @Value("${spring.jwt.expirationMillis}")
+    private long expirationMillis;
+
+    // 서명(Signature)에 사용할 Key 객체 생성 (HS256 알고리즘)
+    private Key getSigningKey() {
+        // Base64로 인코딩된 시크릿 키를 디코딩해서 Key 생성 (만약 yaml에 Base64 문자열로 적어두셨다면)
+        // byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        // return Keys.hmacShaKeyFor(keyBytes);
+
+        // 만약 plain-text 형태로 적어두셨다면(간단히 getBytes() 해서 사용)
+        byte[] keyBytes = secretKey.getBytes(); 
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * 1) JWT 토큰 발급 메서드
+     *    - user 객체에서 필요한 정보를 꺼내서 claim으로 넣을 수 있다.
+     *    - 예시로 userId, loginId를 subject 및 claim에 넣고, 발급 시각/만료 시각을 설정했다.
+     */
+    public String generateToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMillis);
+
+        return Jwts.builder()
+                .setSubject(user.getLoginId())            // 토큰의 subject: 여기서는 로그인 ID
+                .claim("userId", user.getUserId())        // 추가로 userId를 claim에 넣어둠
+                // .claim("roles", user.getRoles())        // (필요하면 권한 정보도 넣어둔다)
+                .setIssuedAt(now)                         // 발급 시간
+                .setExpiration(expiry)                    // 만료 시간
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 2) JWT 토큰에서 userId 추출 (Claim에서 가져오는 예시)
+     *    토큰을 검증한 뒤, 내부 claim에 담겨있는 userId를 꺼낸다.
+     */
+    public Long getUserIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        // claim에서 꺼낼 때 Long 타입으로 캐스팅
+        return claims.get("userId", Long.class);
+    }
+
+    /**
+     * 3) 토큰 유효성 검증 메서드
+     *    - 시그니처 확인, 만료 시간 확인 등을 수행
+     *    - 유효하면 true, 아니면 예외를 던지거나 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            // parseClaims() 내부에서 서명 및 만료 시간 검증이 이루어진다.
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException ex) {
+            // 토큰이 만료된 경우
+            System.out.println("JWT 만료: " + ex.getMessage());
+        } catch (UnsupportedJwtException ex) {
+            System.out.println("지원하지 않는 JWT: " + ex.getMessage());
+        } catch (MalformedJwtException ex) {
+            System.out.println("잘못된 JWT 서식: " + ex.getMessage());
+        } catch (SignatureException ex) {
+            System.out.println("JWT 서명 검증 실패: " + ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            System.out.println("JWT 토큰이 비었거나 잘못됨: " + ex.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * 파싱해서 Claims를 반환하는 내부 헬퍼 메서드
+     * -> validateToken(...)에서 참고하고, getUserIdFromToken(...)에서도 사용한다.
+     */
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)    // JWS 서명 검증 및 claims 파싱
+                .getBody();
+    }
+}

--- a/src/main/java/com/syu/cara/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/syu/cara/user/service/CustomUserDetailsService.java
@@ -1,0 +1,61 @@
+package com.syu.cara.user.service;
+
+import com.syu.cara.user.domain.User;
+import com.syu.cara.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT에서 추출한 userId를 기반으로 DB에서 User를 조회하고,
+ * Spring Security에게 필요한 UserDetails 타입으로 변환해서 반환하는 서비스
+ */
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * (1) JWT 필터가 userId를 갖고 있는 상황을 가정합니다.
+     *     여기서는 loadUserById 메서드를 별도로 만들어 userId로 조회하고,
+     *     기존 UserDetailsService의 loadUserByUsername은 username(즉 loginId) 기반 조회를 지원합니다.
+     */
+
+    // JWT 필터에서 userId를 직접 넘겨받아 사용할 메서드
+    public UserDetails loadUserById(Long userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+
+        return toUserDetails(user);
+    }
+
+    // (2) username(=loginId) 기반 인증을 지원하려면 반드시 이 메서드가 loginId 조회를 해야 합니다.
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        // ★ 여기서 findByKakaoId(loginId) 가 아니라, findByLoginId(loginId) 로 바꿔야 합니다.
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with loginId: " + loginId));
+
+        return toUserDetails(user);
+    }
+
+    // User 엔티티를 Spring Security가 필요로 하는 UserDetails로 변환
+    private UserDetails toUserDetails(User user) {
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getLoginId())
+                // JWT 기반 인증만 쓸 거라면 passwordHash를 빈 문자열("")로 두셔도 무방합니다.
+                .password(user.getPasswordHash() == null ? "" : user.getPasswordHash())
+                // 권한이 없다면 빈 배열, 필요하다면 "ROLE_USER" 등 추가
+                .authorities(/* new String[]{"ROLE_USER"} */ new String[]{})
+                .accountExpired(false)
+                .accountLocked(false)
+                .credentialsExpired(false)
+                .disabled(false)
+                .build();
+    }
+}

--- a/src/main/java/com/syu/cara/user/service/UserProfileService.java
+++ b/src/main/java/com/syu/cara/user/service/UserProfileService.java
@@ -1,0 +1,7 @@
+package com.syu.cara.user.service;
+
+import com.syu.cara.user.dto.UserProfileResponse;
+
+public interface UserProfileService {
+    UserProfileResponse getMyProfile();
+}

--- a/src/main/java/com/syu/cara/user/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/syu/cara/user/service/UserProfileServiceImpl.java
@@ -1,0 +1,36 @@
+package com.syu.cara.user.service;
+
+import com.syu.cara.user.domain.User;
+import com.syu.cara.user.dto.UserProfileResponse;
+import com.syu.cara.user.repository.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserProfileServiceImpl implements UserProfileService {
+
+    private final UserRepository userRepo;
+
+    public UserProfileServiceImpl(UserRepository userRepo) {
+        this.userRepo = userRepo;
+    }
+
+    @Override
+    public UserProfileResponse getMyProfile() {
+        String loginId = SecurityContextHolder.getContext()
+                              .getAuthentication()
+                              .getName();
+
+        User user = userRepo.findByLoginId(loginId)
+            .orElseThrow(() -> new RuntimeException("로그인된 사용자를 찾을 수 없습니다."));
+
+        return new UserProfileResponse(
+            user.getLoginId(),
+            user.getEmail(),
+            user.getFullName(),
+            user.getProfileImageUrl(),
+            user.getDriverLicenseNumber(),
+            user.getAddress()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
     client:
       client-id: 7c13edee67bab4b026ddc1256ec88eeb
       client-secret: ""
-      redirect-uri: http://localhost:8080/oauth/kakao/callback
+      redirect-uri: http://localhost:8080/v1/oauth/kakao/callback
 
   jwt:
     secret: VeryLongRandomSecretKeyForHMACSHA256Signing

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,13 @@ spring:
   ai:
     openai:
       api-key: ${SPRING_AI_OPENAI_API_KEY}
+
+  kakao:
+    client:
+      client-id: 7c13edee67bab4b026ddc1256ec88eeb
+      client-secret: ""
+      redirect-uri: http://localhost:8080/oauth/kakao/callback
+
+  jwt:
+    secret: VeryLongRandomSecretKeyForHMACSHA256Signing
+    expirationMillis: 1209600000   # 14일(2주)를 밀리초로 환산 (14 * 24 * 60 * 60 * 1000)

--- a/src/test/java/com/syu/cara/user/controller/UserControllerTest.java
+++ b/src/test/java/com/syu/cara/user/controller/UserControllerTest.java
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/com/syu/cara/user/controller/UserControllerTest.java
+++ b/src/test/java/com/syu/cara/user/controller/UserControllerTest.java
@@ -1,0 +1,71 @@
+package com.syu.cara.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.syu.cara.user.domain.User;
+import com.syu.cara.user.repository.UserRepository;
+import com.syu.cara.user.security.JwtService;
+import com.syu.cara.user.service.CustomUserDetailsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper om;
+    @MockBean
+    JwtService jwtService;
+    @MockBean
+    CustomUserDetailsService userDetailsService;
+    @MockBean
+    UserRepository userRepo;
+
+    @Test
+    void getMyProfile_success() throws Exception {
+        // 1) JWT 검증, UserDetails 세팅
+        String token = "dummy.jwt.token";
+        when(jwtService.validateToken(token)).thenReturn(true);
+        when(jwtService.getUserIdFromToken(token)).thenReturn(42L);
+
+        User user = User.builder()
+                        .loginId("kakao_42")
+                        .email("u@ex.com")
+                        .fullName("테스터")
+                        .profileImageUrl("url")
+                        .driverLicenseNumber("DL")
+                        .address("addr")
+                        .build();
+        when(userRepo.findById(42L)).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/v1/users/me")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.loginId").value("kakao_42"))
+            .andExpect(jsonPath("$.email").value("u@ex.com"))
+            .andExpect(jsonPath("$.fullName").value("테스터"));
+    }
+
+    @Test
+    void getMyProfile_unauthorized() throws Exception {
+        when(jwtService.validateToken(any())).thenReturn(false);
+
+        mockMvc.perform(get("/api/v1/users/me")
+                .header("Authorization", "Bearer bad.token"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/syu/cara/user/service/UserProfileServiceImplTest.java
+++ b/src/test/java/com/syu/cara/user/service/UserProfileServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.syu.cara.user.service;
+
+import com.syu.cara.user.domain.User;
+import com.syu.cara.user.dto.UserProfileResponse;
+import com.syu.cara.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserProfileServiceImplTest {
+    
+    @Mock
+    private UserRepository userRepo;
+    
+    @InjectMocks
+    private UserProfileServiceImpl profileService;
+    
+    @Test
+    void getMyProfile_returnsCorrectResponse() {
+        // 1) SecurityContext에 사용자 세팅
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("kakao_12345", null)
+        );
+        
+        // 2) userRepo가 가짜 User 반환
+        User fake = User.builder()
+                        .loginId("kakao_12345")
+                        .email("foo@bar.com")
+                        .fullName("홍길동")
+                        .profileImageUrl("http://img")
+                        .driverLicenseNumber("DL123")
+                        .address("서울")
+                        .build();
+        when(userRepo.findByLoginId("kakao_12345")).thenReturn(Optional.of(fake));
+        
+        // 3) 서비스 호출
+        UserProfileResponse dto = profileService.getMyProfile();
+        
+        // 4) 검증
+        assertEquals("kakao_12345", dto.getLoginId());
+        assertEquals("foo@bar.com", dto.getEmail());
+        assertEquals("홍길동", dto.getFullName());
+        // …나머지도 검증
+    }
+    
+    @Test
+    void getMyProfile_whenNotFound_throws() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("no_user", null)
+        );
+        when(userRepo.findByLoginId("no_user")).thenReturn(Optional.empty());
+        
+        assertThrows(RuntimeException.class, () -> profileService.getMyProfile());
+    }
+}


### PR DESCRIPTION
## 작업 개요
- 카카오 OAuth 연동을 통해 사용자 인증
- 인증된 사용자 정보를 데이터베이스에 저장하는 기능 구현
- JWT 발급하여  인증을 처리할 수 있는 보안 흐름 완성


## 작업 내용
1. User Entity : 엔티티 및 스키마 변경
 - 기존 필드(userId, loginId, email, fullname, profileImageUrl)에 더해 passwordHash 칼럼을 not null 제약조건을 유지하되, 카카오 로그인 시에는 빈 문자열로 채우도록 수정
2. KakaoClient : 카카오 API 연동 클라이언트
 - 인가코드 -> 엑세스 토큰 요청 : client_id, redirect_uri, code 파라미터 전달 후, access_token 리턴
 - 엑세스 토큰 -> 사용자 정보 요청 : KakaoUserInfoDTO 형태로 매핑
3. DTO
 - KakaoAuthRequest : 클라이언트(FE)에서 전달하는 카카오 액세스 토큰
 - KakaoAuthResponse : 카카오 로그인 후 사용자 정보를 DB에 저장하고 JWT 함께 리턴 
 - KakaoUserInfoDTO : 카카오 Rest API에서 내려오는 JSON 구조에 맞춰 생성
4. Controller
 - KakaoOAuthController : 요청 바디에 담긴 accessToken을 받아 카카오 서버로부터 프로필 정보 조회
 - 조회된 kakaoId가 DB에 존재하지 않으면 새로운 User 엔티티 생성하여 저장
 - JWTService를 통해 2주 만료기간으로 JWT 생성
 - KakaoAuthResponse로 userId, loginId, isNewUser, jwtToken 값 반환
5. JWT 인증 로직 : JwtService, JwtAuthenticationFilter
 - JwtService/generateToken 메서드 : 발급 시각, 만료시각 설정
 - JwtService/getUserIdFromToken 메서드 : 토큰 파싱 후 userId를 Long 타입으로 리턴
 - JwtService/validateToken 메서드 : 만료, 서명, 포맷 검증 수행 / 예외 발생 시 false 리턴
 -  JwtAuthenticationFilter : 모든 요청에 대해 헤더 확인

 
## 테스트 내용
- 로컬에서 애플리케이션 실행/Redirect URI 등록/인가 코드 받은 후 엔드포인트 호출
![image](https://github.com/user-attachments/assets/e671a1f7-ca4a-48eb-a4ca-364e25940e68)

- 정상 응답 예시
![image](https://github.com/user-attachments/assets/60e62405-4add-4b7a-9094-d8c79c3e5704)

- 응답 후 PostgreSQL 콘솔에 정상 저장
![image](https://github.com/user-attachments/assets/fa4a67ca-4ae1-4cba-81b2-7ca14c64a269)


## 참고 사항
- Kakao에 비즈니스 앱 등록 이후 추가적인 사용자 정보 권한 받을 수 있음
- 호출 엔드포인트 수정 필요