### PR TITLE
feat(user) : 로그아웃 API 추가

### DIFF
--- a/src/main/java/com/syu/cara/config/SecurityConfig.java
+++ b/src/main/java/com/syu/cara/config/SecurityConfig.java
@@ -34,6 +34,8 @@ public class SecurityConfig {
               .requestMatchers("/api/v1/auth/kakao", "/oauth/kakao/callback").permitAll()
               // 사용자 정보 조회는 JWT 인증 필요
               .requestMatchers("/api/v1/users/me").authenticated()
+              // logout 엔드포인트 허용
+              .requestMatchers("/api/v1/auth/logout").permitAll()
               // 나머지 요청도 인증 필요
               .anyRequest().authenticated()
           )

--- a/src/main/java/com/syu/cara/user/controller/LogoutController.java
+++ b/src/main/java/com/syu/cara/user/controller/LogoutController.java
@@ -1,0 +1,30 @@
+package com.syu.cara.user.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 로그아웃 처리용 컨트롤러
+ * 클라이언트에 저장된 JWT 쿠키를 삭제하고 204 No Content를 반환
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+public class LogoutController {
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        // JWT를 HttpOnly 쿠키에 저장하는 경우에만 쿠키를 삭제합니다.
+        Cookie cookie = new Cookie("jwtToken", null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+
+        // 클라이언트 로컬 스토리지나 세션 스토리지는 클라이언트 측에서 삭제
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
## 작업 개요
- 클라이언트가 저장한 JWT 쿠키 삭제
- 로그아웃 처리하는 엔드포인트 추가

## 작업 내용
1. LogoutController 추가
 - /api/v1/auth/logout 요청 시 쿠키에 저장된 jwtToken 값 삭제 처리
2. SecurityConfig 수정
 - 로그아웃 엔드포인트를 인정 없이 접근 가능하도록 permitAll() 추가

## 테스트 내용
- POST /api/v1/auth/logout 호출 시 204 No Content 발생


## 참고 사항
- 프론트엔드에서 로그아웃 성공 응답 후 로컬 스토리지에 남아있는 JWT도 반드시 삭제해야함