### PR TITLE
feat(user) : 자동 로그아웃 처리 - 만료된 JWT 토큰 검증 및 401 응답 구현

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,6 @@ spring:
     secret: VeryLongRandomSecretKeyForHMACSHA256Signing
     expirationMillis: 1209600000   # 14일(2주)를 밀리초로 환산 (14 * 24 * 60 * 60 * 1000)
 
-<<<<<<< feature/user_kakaoAuth/_minsu
 # application.yml (공통)
 app:
   security:
@@ -41,10 +40,3 @@ app:
 app:
   security:
     enabled: false   # 테스트 돌릴 땐 시큐리티 비활성화
-=======
-  security:
-    user:
-      name: user
-      password: 1234
-
->>>>>>> feature/user_kakaoAuth/_main

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+# src/test/resources/application.yml
+
+app:
+  security:
+    enabled: false   # 테스트 돌릴 땐 시큐리티 비활성화


### PR DESCRIPTION
## 작업 개요
- 토큰 만료시 자동 로그아웃 처리를 위한 토큰 검증, 401 응답 구현
- 테스트 목적의 application.yml 파일 분리

## 작업 내용
1. JwtService
 - 만료된 토큰의 경우 예외(ExpriedJwtException)를 잡아 false 리턴하도록 수정
2. JwtAuthenticationFilter
 - 토큰 결과가 false인 경우(만료 or 유효하지 않은) 보안 설정을 건너뛰고, 바로 401 상태 반환하도록 응답 수정
3. src/test/resources/application.yml
 - main 내 yml 파일과 분리하여 테스트 시 security 를 건너뛰도록 함.

## 테스트 내용
- 


## 참고 사항 : 프론트 작업 관련
- API 호출에서 401 응답을 인터셉트하도록 공통 HTTP 클라이언트에 설정
- 401 응답이 왔을 경우 : 로컬 스토리지에 저장된 JWT 토큰 삭제 -> 사용자에게 알림 -> 로그인 페이지(/login) 리다이렉트