### PR TITLE
feat(user) : 회원 정보 조회 로직 테스트

### DIFF
--- a/src/main/java/com/syu/cara/config/SecurityConfig.java
+++ b/src/main/java/com/syu/cara/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                     "/api/v1/auth/signup",
                     "/api/v1/auth/login",
                     "/api/v1/auth/logout",
+                    "/api/v1/auth/kakao/logout",
                     "/api/v1/auth/kakao/callback"
                 ).permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/syu/cara/user/controller/KakaoOAuthController.java
+++ b/src/main/java/com/syu/cara/user/controller/KakaoOAuthController.java
@@ -76,8 +76,8 @@ public class KakaoOAuthController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse response) {
+    @PostMapping("/kakao/logout")
+    public ResponseEntity<Void> kakaoLogout(HttpServletResponse response) {
         // JWT를 HttpOnly 쿠키에 저장하는 경우에만 쿠키를 삭제합니다.
         Cookie cookie = new Cookie("jwtToken", null);
         cookie.setHttpOnly(true);

--- a/src/main/java/com/syu/cara/user/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/syu/cara/user/security/JwtAuthenticationFilter.java
@@ -39,9 +39,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = header.substring(7);
             try {
                 // 2) 토큰 검증
-                if (jwtService.validateToken(token)) {
+                if (!jwtService.validateToken(token)) {
                     // 유효하지 않은 토큰 (만료 등)
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired JWT token");
+                    return;
                 }
 
                 // 3) 토큰에서 꺼낸 userId 또는 loginId 정보를 통해 UserDetails 조회


### PR DESCRIPTION
## 작업 개요
- Postman 으로 

## 작업 내용
 1. JwtAuthenticationFilter 
 - validateToken 이 true일 때 401 오류를 보내던 것을 수정
 - 토큰이 유효하지 않을 때 필터 체인을 중단하도록 return 문 추가
 

## 테스트 내용
- Postman 사용하여 jwtToken 입력 후 사용자 정보 조회 정상적으로 동작하는 것 확인
![image](https://github.com/user-attachments/assets/b51aa7d2-415f-467b-816c-dbe19b6f798e)


## 참고 사항 : 