### PR TITLE
recommendation 이미 예약된 차량 필터링 기능 구현

### DIFF
--- a/src/main/java/com/syu/cara/recommendation/service/LLMRecommendationService.java
+++ b/src/main/java/com/syu/cara/recommendation/service/LLMRecommendationService.java
@@ -11,10 +11,15 @@ import com.syu.cara.recommendation.openai.ResponseParser;
 import com.syu.cara.car.repository.CarRepository;
 import com.syu.cara.recommendation.repository.RecommendationRepository;
 import com.syu.cara.rentalrequest.repository.PromptHistoryRepository;
+import com.syu.cara.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +32,7 @@ public class LLMRecommendationService {
     private final PromptHistoryRepository promptHistoryRepository;
     private final DomainClassifier domainClassifier;
     private final CarRepository carRepository;
+    private final ReservationRepository reservationRepository;
 
     public List<RecommendationResponse> generateRecommendation(String userInput) {
 
@@ -40,7 +46,30 @@ public class LLMRecommendationService {
         RentalCondition condition = bundle.getCondition();
         String gptMessage = bundle.getNaturalLanguageMessage();
 
-        List<Car> candidates = carRepository.findAllWithAgency(); // → fetch join으로
+        // 날짜 파싱
+        LocalDate rentalDate = parseDate(condition.getRentalDate());
+        LocalDate returnDate = parseDate(condition.getReturnDate());
+        
+        // 날짜가 유효하지 않은 경우 기본값 설정
+        if (rentalDate == null) {
+            rentalDate = LocalDate.now().plusDays(1);
+        }
+        if (returnDate == null) {
+            returnDate = rentalDate.plusDays(3);
+        }
+        
+        // 만약 반납일이 대여일보다 이전이면 조정
+        if (returnDate.isBefore(rentalDate)) {
+            returnDate = rentalDate.plusDays(1);
+        }
+        
+        System.out.println("🗓️ 대여 기간: " + rentalDate + " ~ " + returnDate);
+
+        List<Car> candidates = carRepository.findAllWithAgency();
+        
+        // 해당 기간에 이미 예약된 차량 ID 목록 조회 (status가 "결제완료"인 예약만 고려)
+        Set<Long> reservedCarIds = reservationRepository.findReservedCarIds(rentalDate, returnDate);
+        System.out.println("🚫 이미 예약된 차량 수: " + reservedCarIds.size());
         
         //추천 조건
         System.out.println("🔍 필터링 시작 - 찾는 지역: " + condition.getPickupLocation());
@@ -50,6 +79,13 @@ public class LLMRecommendationService {
 
         List<Car> filtered = candidates.stream()
                 .filter(car -> {
+                    // 1. 이미 예약된 차량 필터링 (가장 먼저 체크)
+                    if (reservedCarIds.contains(car.getCarId())) {
+                        System.out.println("🚫 예약 불가: " + car.getModelName() + " (이미 예약됨)");
+                        return false;
+                    }
+                    
+                    // 2. 지역 필터링
                     if (condition.getPickupLocation() == null) return true;
 
                     // 디버깅 로그
@@ -168,6 +204,21 @@ public class LLMRecommendationService {
         }
 
         return "제주"; // 기본값
+    }
+
+    // 날짜 문자열을 LocalDate로 파싱하는 메서드
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.isEmpty()) {
+            return null;
+        }
+        
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        try {
+            return LocalDate.parse(dateStr, formatter);
+        } catch (DateTimeParseException e) {
+            System.err.println("날짜 형식이 잘못되었습니다: " + dateStr);
+            return null;
+        }
     }
 
 }

--- a/src/main/java/com/syu/cara/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/syu/cara/reservation/repository/ReservationRepository.java
@@ -3,6 +3,25 @@ package com.syu.cara.reservation.repository;
 
 import com.syu.cara.reservation.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Set;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    
+    /**
+     * 특정 기간에 이미 예약된 차량 ID 목록을 조회합니다.
+     * 두 기간이 하루라도 겹치면 예약된 것으로 간주합니다.
+     * status가 "결제완료"인 예약만 고려합니다.
+     * 
+     * @param startDate 대여 시작일
+     * @param endDate 대여 종료일
+     * @return 예약된 차량 ID 집합
+     */
+    @Query("SELECT r.recommendation.car.carId FROM Reservation r " +
+           "WHERE (r.rentalDate <= :endDate AND r.returnDate >= :startDate) " +
+           "AND r.status = '결제완료'")
+    Set<Long> findReservedCarIds(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 }


### PR DESCRIPTION
**ReservationRepository.java**

- 기존 예약의 시작일(r.rentalDate)이 요청된 종료일(endDate) 이전이고
- 기존 예약의 종료일(r.returnDate)이 요청된 시작일(startDate) 이후인 경우
  그리고 예약 상태가 "결제완료"인 경우

     * 특정 기간에 이미 예약된 차량 ID 목록을 조회합니다.
     * 두 기간이 하루라도 겹치면 예약된 것으로 간주합니다.
     * status가 "결제완료"인 예약만 고려합니다.
     * 
     * @param startDate 대여 시작일
     * @param endDate 대여 종료일
     * @return 예약된 차량 ID 집합

- 쿼리가 status = '결제완료'인 예약만 고려
- status가 "결제완료"인 예약은 해당 차량을 추천 목록에서 제외
- status가 "결제취소" 또는 "반납완료"인 예약은 해당 차량을 추천 목록에 포함
---

이 조건은 두 기간이 하루라도 겹치는 모든 경우를 포함.
- 기존 예약: 6/1 ~ 6/5, 새 요청: 6/3 ~ 6/7 (중간이 겹침)
- 기존 예약: 6/1 ~ 6/5, 새 요청: 6/5 ~ 6/10 (끝과 시작이 겹침)
- 기존 예약: 6/3 ~ 6/7, 새 요청: 6/1 ~ 6/10 (새 요청이 기존 예약을 포함)
- 기존 예약: 6/1 ~ 6/10, 새 요청: 6/3 ~ 6/7 (기존 예약이 새 요청을 포함)